### PR TITLE
Use make to handle build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,33 @@
-FILES=src/title.md src/acknowledgements.md src/trademarks.md src/intro.md src/chapter-01.md src/chapter-02.md src/chapter-03.md src/chapter-04.md src/chapter-05.md src/chapter-06.md src/chapter-07.md src/chapter-08.md src/chapter-09.md src/chapter-10.md src/chapter-11.md src/chapter-12.md src/chapter-13.md src/chapter-14.md src/chapter-15.md src/chapter-16.md src/listings.md src/appendix-a.md src/appendix-b.md src/about-this-version.md
+.POSIX:
+.PHONY: html epub mobi clean
 
-.PHONY: html epub
+FILES=$(wildcard src/*.md)
+NAME=zen-of-asm
 
 all: html epub mobi
 
-html:
-	rm -rf out/html && mkdir -p out/html
+html: out/html/zen-of-asm.html
+epub: out/zen-of-asm.epub
+mobi: out/zen-of-asm.mobi
+
+out/html/$(NAME).html: $(FILES) out html/book.css html/template.html
+	mkdir -p out/html
 	cp -r images html/book.css out/html/
-	pandoc -f markdown+smart --to html5 -o out/html/zen-of-asm.html --section-divs --toc --toc-depth=2 --standalone --template=html/template.html --ascii $(FILES)
+	pandoc -f markdown+smart --to html5 -o $@ \
+		--section-divs --toc --toc-depth=2 --standalone \
+		--template=html/template.html --ascii $(FILES)
 
-epub:
-	mkdir -p out
-	rm -f out/zen-of-asm.epub
-	pandoc -f markdown+smart --to epub3 -o out/zen-of-asm.epub --epub-cover-image images/cover.png --toc --toc-depth=2 --epub-chapter-level=2 --data-dir=epub --template=epub/template.html $(FILES)
+out/$(NAME).epub: $(FILES) out
+	pandoc -f markdown+smart --to epub3 -o $@ \
+		--epub-cover-image images/cover.png --toc --toc-depth=2 \
+		--epub-chapter-level=2 --data-dir=epub \
+		--template=epub/template.html $(FILES)
 
-mobi:
-	rm -f out/zen-of-asm.mobi
+out/$(NAME).mobi: $(FILES) epub
 	kindlegen out/zen-of-asm.epub -c2
+
+out:
+	mkdir out
+
+clean:
+	rm -rf out/


### PR DESCRIPTION
make will now

 - build the epub version before the mobi
 - only rebuild the targets if the source files are newer
 - added a clean target to remove the build targets
 - added a target to make the out folder

 Also cleaned up the targets by wrapping at column 80.
 Use a make function to find the source file names, instead of manually
 listing them.